### PR TITLE
isInboundDone() used in decoding loop

### DIFF
--- a/src/main/java/org/reaktivity/nukleus/tls/internal/stream/ClientStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/tls/internal/stream/ClientStreamFactory.java
@@ -799,7 +799,7 @@ public final class ClientStreamFactory implements StreamFactory
                     inNetByteBuffer.limit(inNetByteBuffer.position() + networkReplySlotOffset + payloadSize);
 
                     loop:
-                    while (inNetByteBuffer.hasRemaining())
+                    while (inNetByteBuffer.hasRemaining() && !tlsEngine.isInboundDone())
                     {
                         outAppByteBuffer.rewind();
                         SSLEngineResult result = tlsEngine.unwrap(inNetByteBuffer, outAppByteBuffer);
@@ -1101,7 +1101,7 @@ public final class ClientStreamFactory implements StreamFactory
                     inNetByteBuffer.limit(inNetByteBuffer.position() + networkReplySlotOffset);
 
                     loop:
-                    while (inNetByteBuffer.hasRemaining())
+                    while (inNetByteBuffer.hasRemaining() && !tlsEngine.isInboundDone())
                     {
                         final ByteBuffer outAppByteBuffer = applicationPool.byteBuffer(applicationReplySlot);
                         outAppByteBuffer.position(outAppByteBuffer.position() + applicationReplySlotOffset);

--- a/src/main/java/org/reaktivity/nukleus/tls/internal/stream/ServerStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/tls/internal/stream/ServerStreamFactory.java
@@ -482,7 +482,7 @@ public final class ServerStreamFactory implements StreamFactory
                     inNetByteBuffer.limit(inNetByteBuffer.position() + networkSlotOffset);
 
                     loop:
-                    while (inNetByteBuffer.hasRemaining())
+                    while (inNetByteBuffer.hasRemaining() && !tlsEngine.isInboundDone())
                     {
                         final ByteBuffer outAppByteBuffer = applicationPool.byteBuffer(applicationSlot);
                         outAppByteBuffer.position(outAppByteBuffer.position() + applicationSlotOffset);
@@ -989,7 +989,7 @@ public final class ServerStreamFactory implements StreamFactory
                     inNetByteBuffer.limit(inNetByteBuffer.position() + networkSlotOffset + payloadSize);
 
                     loop:
-                    while (inNetByteBuffer.hasRemaining())
+                    while (inNetByteBuffer.hasRemaining() && !tlsEngine.isInboundDone())
                     {
                         outAppByteBuffer.rewind();
                         HandshakeStatus handshakeStatus = NOT_HANDSHAKING;


### PR DESCRIPTION
isInboundDone() used in decoding loop to break infinite loop
- SSLEngineResult may be CLOSED state and if there is some data to be decoded, it just spins in the  loop.
- I see that isOutboundDone() used similarly while encoding