### PR TITLE
Buffered data in budget calculations

### DIFF
--- a/src/main/java/org/reaktivity/nukleus/tls/internal/stream/ClientStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/tls/internal/stream/ClientStreamFactory.java
@@ -507,13 +507,7 @@ public final class ClientStreamFactory implements StreamFactory
         {
             networkWindowBudget += window.credit();
             networkWindowPadding = applicationWindowPadding = window.padding();
-            final int applicationWindowCredit = networkWindowBudget - applicationWindowBudget;
-
-            if (applicationWindowCredit > 0)
-            {
-                applicationWindowBudget += applicationWindowCredit;
-                doWindow(applicationThrottle, applicationId, applicationWindowCredit, applicationWindowPadding);
-            }
+            sendApplicationWindow();
         }
 
         private void handleReset(
@@ -1371,7 +1365,7 @@ public final class ClientStreamFactory implements StreamFactory
                 }
             }
 
-            final int networkWindowCredit = applicationReplyWindowBudget - networkReplyWindowBudget;
+            final int networkWindowCredit = applicationReplyWindowBudget - networkReplyWindowBudget - networkReplySlotOffset;
 
             if (networkWindowCredit > 0)
             {


### PR DESCRIPTION
window credit needs to take buffered data into calculations so that too much
credit is not given.