### PR TITLE
Removing tls transport in extension data test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.28</nukleus.plugin.version>
     <nukleus.version>0.21</nukleus.version>
 
-    <nukleus.tls.spec.version>0.24</nukleus.tls.spec.version>
+    <nukleus.tls.spec.version>develop-SNAPSHOT</nukleus.tls.spec.version>
     <reaktor.version>0.56</reaktor.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.28</nukleus.plugin.version>
     <nukleus.version>0.21</nukleus.version>
 
-    <nukleus.tls.spec.version>develop-SNAPSHOT</nukleus.tls.spec.version>
+    <nukleus.tls.spec.version>0.25</nukleus.tls.spec.version>
     <reaktor.version>0.56</reaktor.version>
   </properties>
 

--- a/src/test/java/org/reaktivity/nukleus/tls/internal/streams/ClientIT.java
+++ b/src/test/java/org/reaktivity/nukleus/tls/internal/streams/ClientIT.java
@@ -94,8 +94,7 @@ public class ClientIT
             "${client}/connection.established.with.extension.data/client",
             "${server}/connection.established.with.extension.data/server" })
     @ScriptProperty({
-            "newServerAcceptRef ${newClientConnectRef}",
-            "serverAccept \"nukleus://target/streams/tls\"" })
+            "newServerAcceptRef ${newClientConnectRef}" })
     public void shouldEstablishConnectionWithExtensionData() throws Exception
     {
         k3po.finish();


### PR DESCRIPTION
Spec test is changed to remove tls transport as it tests whether the begin
extension data is passed to target nukleus